### PR TITLE
feat(signin): add endpoint functionality

### DIFF
--- a/UI/js/signin.js
+++ b/UI/js/signin.js
@@ -1,0 +1,30 @@
+let submit = document.getElementById('submit');
+let email = document.getElementById('email');
+let password = document.getElementById('password');
+let form = document.getElementById('form');
+
+
+const url = 'https://stack-o-lite.herokuapp.com/api/v1/auth/login';
+
+form.addEventListener('submit', (e) => {
+    e.preventDefault()
+    let data = {
+        email: email.value,
+        password: password.value,
+    }
+    const req = new Request(url, {
+        method: 'POST',
+        headers: new Headers({'Content-type': 'application/json'}),
+        body: JSON.stringify(data),
+    })
+    
+    fetch(req)
+        .then((res) => res.json())
+        .then(data => {
+            if (data.status === 'success') {
+                location = './question.html'
+            } else {
+                alert(data.message)
+            }
+        })
+});

--- a/UI/signin.html
+++ b/UI/signin.html
@@ -11,7 +11,7 @@
     <section class="content-wrapper">
         <header><img src="./img/stacklight-logo.svg" alt="StackLite Logo"></header>
 
-        <form action="">
+        <form action="" id="form">
             <div>
                 <p>Sign in to StackLite</p>
             </div>
@@ -24,10 +24,13 @@
                     <input type="password" id="password" required>
                 </div>
                 <div>
-                    <input type="submit">
+                    <input type="submit" id="submit">
+                </div>
+                <div>
+                    <a href="signup.html">Sign up</a>
                 </div>
         </form>
     </section>
-    
+    <script src="./js/signin.js"></script>
 </body>
 </html>

--- a/UI/signup.html
+++ b/UI/signup.html
@@ -31,6 +31,7 @@
                 <label for="">confirm password</label>
                 <input type="text" placeholder="confirm password" id="confirmPassword">
                 <button id="signupBtn">SIGN UP</button>
+                <a href="./signin.html">Sign in</a>
             </form>
         </section>
 


### PR DESCRIPTION
#### What does this PR do?
Add signin endpoint functionality

#### Description of Task to be completed?
Have this endpoint working:
```signin.html```

#### How should this be manually tested?
After cloning the repo, cd into the repo ```cd quickcredit```,  navigate to ```signin.html``` from your browser

#### Any background context you want to provide?
Nill

#### What are the relevant pivotal tracker stories?
#166118348

#### Screenshots (if appropriate)
Nil

#### Questions:
Nil


[Finishes #166118348]